### PR TITLE
Add Airline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ _Note that I’ve only added screenshots of the light and dark variants for the 
 <details>
 <summary>Usage</summary>
 
-If you’re using a GUI, then vim-colors-xcode should work out of the box. However, if you’re planning to use vim-colors-xcode in a terminal, the terminal must support 24-bit colour, also known as True Colour. If you want other terminal output to match with vim-colors-xcode, then set its colours to match the ones below:
+If you’re using a GUI, then vim-colors-xcode should work out of the box. However, if you’re planning to use vim-colors-xcode in a terminal, the terminal must support 24-bit colour, also known as True Colour. This can be enabled through the use of the following setting:
+
+```viml
+set termguicolors
+```
+
+If you want other terminal output to match with vim-colors-xcode, then set its colours to match the ones below:
 
 <details>
 <summary>Dark Palette</summary>

--- a/autoload/airline/themes/xcodedark.vim
+++ b/autoload/airline/themes/xcodedark.vim
@@ -1,0 +1,114 @@
+" Name:         xcodedark
+" Description:  A Vim port of the default dark Xcode 11 colourscheme
+" Author:       Aramis
+" Maintainer:   Aramis Razzaghipour <aramisnoah@gmail.com>
+" License:      Vim License (see `:help license`)
+
+let g:airline#themes#xcodedark#palette = {}
+
+function! airline#themes#xcodedark#refresh()
+  " Normal mode
+  let s:N1 = ['#292a30', '#a3b1bf', '']
+  let s:N2 = [s:N1[0], '#7f8c98', '']
+  let s:N3 = ['#dfdfe0', '#414453', '']
+  let s:NW = [s:N1[0], '#ff8170', '']
+  let s:NM = ['#dabaff', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '#d9c97c', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '#ff7ab2', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '#b281eb', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#xcodedark#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#xcodedark#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#xcodedark#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#xcodedark#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodedark#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodedark#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#xcodedark#palette.normal_modified.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#xcodedark#palette.insert.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#xcodedark#palette.insert_modified.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#xcodedark#palette.visual.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#xcodedark#palette.visual_modified.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#xcodedark#palette.replace.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#xcodedark#palette.replace_modified.airline_warning =
+        \ g:airline#themes#xcodedark#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedark#palette.tabline = {}
+
+  let g:airline#themes#xcodedark#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#xcodedark#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#xcodedark#refresh()

--- a/autoload/airline/themes/xcodedarkhc.vim
+++ b/autoload/airline/themes/xcodedarkhc.vim
@@ -1,0 +1,114 @@
+" Name:         xcodedarkhc
+" Description:  A Vim port of the high contrast dark Xcode 11 colourscheme
+" Author:       Aramis
+" Maintainer:   Aramis Razzaghipour <aramisnoah@gmail.com>
+" License:      Vim License (see `:help license`)
+
+let g:airline#themes#xcodedarkhc#palette = {}
+
+function! airline#themes#xcodedarkhc#refresh()
+  " Normal mode
+  let s:N1 = ['#1f1f24', '#aeb7c0', '']
+  let s:N2 = [s:N1[0], '#838991', '']
+  let s:N3 = ['#ffffff', '#43454b', '']
+  let s:NW = [s:N1[0], '#ff8a7a', '']
+  let s:NM = ['#e5cfff', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '#d9c668', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '#ff85b8', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '#cda1ff', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#xcodedarkhc#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#xcodedarkhc#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#xcodedarkhc#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#xcodedarkhc#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodedarkhc#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodedarkhc#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#xcodedarkhc#palette.normal_modified.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#xcodedarkhc#palette.insert.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#xcodedarkhc#palette.insert_modified.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#xcodedarkhc#palette.visual.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#xcodedarkhc#palette.visual_modified.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#xcodedarkhc#palette.replace.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#xcodedarkhc#palette.replace_modified.airline_warning =
+        \ g:airline#themes#xcodedarkhc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodedarkhc#palette.tabline = {}
+
+  let g:airline#themes#xcodedarkhc#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#xcodedarkhc#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#xcodedarkhc#refresh()

--- a/autoload/airline/themes/xcodelight.vim
+++ b/autoload/airline/themes/xcodelight.vim
@@ -1,0 +1,114 @@
+" Name:         xcodelight
+" Description:  A Vim port of the default light Xcode 11 colourscheme
+" Author:       Aramis
+" Maintainer:   Aramis Razzaghipour <aramisnoah@gmail.com>
+" License:      Vim License (see `:help license`)
+
+let g:airline#themes#xcodelight#palette = {}
+
+function! airline#themes#xcodelight#refresh()
+  " Normal mode
+  let s:N1 = ['#ffffff', '#5c6873', '']
+  let s:N2 = [s:N1[0], '#8a99a6', '']
+  let s:N3 = ['#262626', '#cdcdcd', '']
+  let s:NW = [s:N1[0], '#d12f1b', '']
+  let s:NM = ['#804fb8', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '#272ad8', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '#ad3da4', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '#4b21b0', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#xcodelight#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#xcodelight#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#xcodelight#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#xcodelight#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodelight#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodelight#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#xcodelight#palette.normal_modified.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#xcodelight#palette.insert.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#xcodelight#palette.insert_modified.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#xcodelight#palette.visual.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#xcodelight#palette.visual_modified.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#xcodelight#palette.replace.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#xcodelight#palette.replace_modified.airline_warning =
+        \ g:airline#themes#xcodelight#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelight#palette.tabline = {}
+
+  let g:airline#themes#xcodelight#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#xcodelight#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#xcodelight#refresh()

--- a/autoload/airline/themes/xcodelighthc.vim
+++ b/autoload/airline/themes/xcodelighthc.vim
@@ -1,0 +1,114 @@
+" Name:         xcodelighthc
+" Description:  A Vim port of the high contrast light Xcode 11 colourscheme
+" Author:       Aramis
+" Maintainer:   Aramis Razzaghipour <aramisnoah@gmail.com>
+" License:      Vim License (see `:help license`)
+
+let g:airline#themes#xcodelighthc#palette = {}
+
+function! airline#themes#xcodelighthc#refresh()
+  " Normal mode
+  let s:N1 = ['#ffffff', '#5c6873', '']
+  let s:N2 = [s:N1[0], '#8a99a6', '']
+  let s:N3 = ['#000000', '#cdcdcd', '']
+  let s:NW = [s:N1[0], '#ad1805', '']
+  let s:NM = ['#703daa', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '#272ad8', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '#9c2191', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '#441ea1', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#xcodelighthc#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#xcodelighthc#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#xcodelighthc#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#xcodelighthc#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodelighthc#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodelighthc#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#xcodelighthc#palette.normal_modified.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#xcodelighthc#palette.insert.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#xcodelighthc#palette.insert_modified.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#xcodelighthc#palette.visual.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#xcodelighthc#palette.visual_modified.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#xcodelighthc#palette.replace.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#xcodelighthc#palette.replace_modified.airline_warning =
+        \ g:airline#themes#xcodelighthc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodelighthc#palette.tabline = {}
+
+  let g:airline#themes#xcodelighthc#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#xcodelighthc#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#xcodelighthc#refresh()

--- a/autoload/airline/themes/xcodewwdc.vim
+++ b/autoload/airline/themes/xcodewwdc.vim
@@ -1,0 +1,114 @@
+" Name:         xcodewwdc
+" Description:  The colours from WWDC 2016’s marketing material
+" Author:       Aramis
+" Maintainer:   Aramis Razzaghipour <aramisnoah@gmail.com>
+" License:      Vim License (see `:help license`)
+
+let g:airline#themes#xcodewwdc#palette = {}
+
+function! airline#themes#xcodewwdc#refresh()
+  " Normal mode
+  let s:N1 = ['#292c36', '#b3b6c0', '']
+  let s:N2 = [s:N1[0], '#7f869e', '']
+  let s:N3 = ['#e7e8eb', '#494d5c', '']
+  let s:NW = [s:N1[0], '#d28e5d', '']
+  let s:NM = ['#b9b5f6', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '#fef937', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '#b73999', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '#8884c5', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#xcodewwdc#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#xcodewwdc#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#xcodewwdc#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#xcodewwdc#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodewwdc#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#xcodewwdc#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#xcodewwdc#palette.normal_modified.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#xcodewwdc#palette.insert.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#xcodewwdc#palette.insert_modified.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#xcodewwdc#palette.visual.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#xcodewwdc#palette.visual_modified.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#xcodewwdc#palette.replace.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#xcodewwdc#palette.replace_modified.airline_warning =
+        \ g:airline#themes#xcodewwdc#palette.normal.airline_warning
+
+  let g:airline#themes#xcodewwdc#palette.tabline = {}
+
+  let g:airline#themes#xcodewwdc#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#xcodewwdc#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#xcodewwdc#refresh()

--- a/templates/_airline_dark.colortemplate
+++ b/templates/_airline_dark.colortemplate
@@ -1,0 +1,116 @@
+auxfile autoload/airline/themes/@shortname.vim
+" Name:         @shortname
+" Description:  @description
+" Author:       @author
+" Maintainer:   @maintainer
+" License:      @license
+
+let g:airline#themes#@shortname#palette = {}
+
+function! airline#themes#@shortname#refresh()
+  " Normal mode
+  let s:N1 = ['@guibase0', '@guibase6', '']
+  let s:N2 = [s:N1[0], '@guibase5', '']
+  let s:N3 = ['@guibase7', '@guibase3', '']
+  let s:NW = [s:N1[0], '@guired', '']
+  let s:NM = ['@guilight_purple', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '@guiyellow', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '@guipink', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '@guipurple', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#@shortname#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#@shortname#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#@shortname#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#@shortname#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#@shortname#palette.normal_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#@shortname#palette.insert.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#@shortname#palette.insert_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#@shortname#palette.visual.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#@shortname#palette.visual_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#@shortname#palette.replace.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#@shortname#palette.replace_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.tabline = {}
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#@shortname#refresh()
+endauxfile

--- a/templates/_airline_darkhc.colortemplate
+++ b/templates/_airline_darkhc.colortemplate
@@ -1,0 +1,116 @@
+auxfile autoload/airline/themes/@shortname.vim
+" Name:         @shortname
+" Description:  @description
+" Author:       @author
+" Maintainer:   @maintainer
+" License:      @license
+
+let g:airline#themes#@shortname#palette = {}
+
+function! airline#themes#@shortname#refresh()
+  " Normal mode
+  let s:N1 = ['@guibase0', '@guibase6', '']
+  let s:N2 = [s:N1[0], '@guibase5', '']
+  let s:N3 = ['@guibase7', '@guibase3', '']
+  let s:NW = [s:N1[0], '@guired', '']
+  let s:NM = ['@guilight_purple', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '@guiyellow', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '@guipink', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '@guipurple', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#@shortname#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#@shortname#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#@shortname#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#@shortname#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#@shortname#palette.normal_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#@shortname#palette.insert.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#@shortname#palette.insert_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#@shortname#palette.visual.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#@shortname#palette.visual_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#@shortname#palette.replace.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#@shortname#palette.replace_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.tabline = {}
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#@shortname#refresh()
+endauxfile

--- a/templates/_airline_light.colortemplate
+++ b/templates/_airline_light.colortemplate
@@ -1,0 +1,116 @@
+auxfile autoload/airline/themes/@shortname.vim
+" Name:         @shortname
+" Description:  @description
+" Author:       @author
+" Maintainer:   @maintainer
+" License:      @license
+
+let g:airline#themes#@shortname#palette = {}
+
+function! airline#themes#@shortname#refresh()
+  " Normal mode
+  let s:N1 = ['@guibase0', '@guibase5', '']
+  let s:N2 = [s:N1[0], '@guibase4', '']
+  let s:N3 = ['@guibase6', '@guibase3', '']
+  let s:NW = [s:N1[0], '@guired', '']
+  let s:NM = ['@guipurple', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '@guistrong_blue', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '@guipink', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '@guidark_purple', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#@shortname#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#@shortname#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#@shortname#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#@shortname#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#@shortname#palette.normal_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#@shortname#palette.insert.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#@shortname#palette.insert_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#@shortname#palette.visual.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#@shortname#palette.visual_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#@shortname#palette.replace.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#@shortname#palette.replace_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.tabline = {}
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#@shortname#refresh()
+endauxfile

--- a/templates/_airline_lighthc.colortemplate
+++ b/templates/_airline_lighthc.colortemplate
@@ -1,0 +1,116 @@
+auxfile autoload/airline/themes/@shortname.vim
+" Name:         @shortname
+" Description:  @description
+" Author:       @author
+" Maintainer:   @maintainer
+" License:      @license
+
+let g:airline#themes#@shortname#palette = {}
+
+function! airline#themes#@shortname#refresh()
+  " Normal mode
+  let s:N1 = ['@guibase0', '@guibase5', '']
+  let s:N2 = [s:N1[0], '@guibase4', '']
+  let s:N3 = ['@guibase6', '@guibase3', '']
+  let s:NW = [s:N1[0], '@guired', '']
+  let s:NM = ['@guipurple', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '@guistrong_blue', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '@guipink', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '@guidark_purple', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#@shortname#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#@shortname#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#@shortname#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#@shortname#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#@shortname#palette.normal_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#@shortname#palette.insert.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#@shortname#palette.insert_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#@shortname#palette.visual.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#@shortname#palette.visual_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#@shortname#palette.replace.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#@shortname#palette.replace_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.tabline = {}
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#@shortname#refresh()
+endauxfile

--- a/templates/_airline_wwdc.colortemplate
+++ b/templates/_airline_wwdc.colortemplate
@@ -1,0 +1,116 @@
+auxfile autoload/airline/themes/@shortname.vim
+" Name:         @shortname
+" Description:  @description
+" Author:       @author
+" Maintainer:   @maintainer
+" License:      @license
+
+let g:airline#themes#@shortname#palette = {}
+
+function! airline#themes#@shortname#refresh()
+  " Normal mode
+  let s:N1 = ['@guibase0', '@guibase6', '']
+  let s:N2 = [s:N1[0], '@guibase5', '']
+  let s:N3 = ['@guibase7', '@guibase3', '']
+  let s:NW = [s:N1[0], '@guiorange', '']
+  let s:NM = ['@guilight_indigo', s:N3[1], '']
+  let s:NMi = s:NM
+
+  " Insert mode
+  let s:I1 = [s:N1[0], '@guideep_yellow', '']
+  let s:I2 = s:N2
+  let s:I3 = s:N3
+  let s:IM = s:NM
+
+  " Visual mode
+  let s:V1 = [s:N1[0], '@guipurple', '']
+  let s:V2 = s:N2
+  let s:V3 = s:N3
+  let s:VM = s:NM
+
+  " Replace mode
+  let s:R1 = [s:N1[0], '@guiindigo', '']
+  let s:R2 = s:N2
+  let s:R3 = s:N3
+  let s:RM = s:NM
+
+  " Inactive
+  let s:IA = [s:N1[0], s:N3[1], '']
+
+  let g:airline#themes#@shortname#palette.inactive = airline#themes#generate_color_map(
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]],
+        \ [s:IA[0], s:IA[1], '', '', s:IA[2]])
+  let g:airline#themes#@shortname#palette.inactive_modified = {
+        \ 'airline_c': [s:NMi[0], '', '', '', s:NMi[2]]}
+
+  let g:airline#themes#@shortname#palette.normal = airline#themes#generate_color_map(
+        \ [s:N1[0], s:N1[1], '', '', s:N1[2]],
+        \ [s:N2[0], s:N2[1], '', '', s:N2[2]],
+        \ [s:N3[0], s:N3[1], '', '', s:N3[2]])
+
+  let g:airline#themes#@shortname#palette.normal.airline_warning = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal.airline_error = [
+        \ s:NW[0], s:NW[1], '', '', s:NW[2]]
+
+  let g:airline#themes#@shortname#palette.normal_modified = {
+        \ 'airline_c': [s:NM[0], s:NM[1], '', '', s:NM[2]]}
+
+  let g:airline#themes#@shortname#palette.normal_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert = airline#themes#generate_color_map(
+        \ [s:I1[0], s:I1[1], '', '', s:I1[2]],
+        \ [s:I2[0], s:I2[1], '', '', s:I2[2]],
+        \ [s:I3[0], s:I3[1], '', '', s:I3[2]])
+
+  let g:airline#themes#@shortname#palette.insert.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.insert_modified = {
+        \ 'airline_c': [s:IM[0], s:IM[1], '', '', s:IM[2]]}
+
+  let g:airline#themes#@shortname#palette.insert_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual = airline#themes#generate_color_map(
+        \ [s:V1[0], s:V1[1], '', '', s:V1[2]],
+        \ [s:V2[0], s:V2[1], '', '', s:V2[2]],
+        \ [s:V3[0], s:V3[1], '', '', s:V3[2]])
+
+  let g:airline#themes#@shortname#palette.visual.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.visual_modified = {
+        \ 'airline_c': [s:VM[0], s:VM[1], '', '', s:VM[2]]}
+
+  let g:airline#themes#@shortname#palette.visual_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace = airline#themes#generate_color_map(
+        \ [s:R1[0], s:R1[1], '', '', s:R1[2]],
+        \ [s:R2[0], s:R2[1], '', '', s:R2[2]],
+        \ [s:R3[0], s:R3[1], '', '', s:R3[2]])
+
+  let g:airline#themes#@shortname#palette.replace.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.replace_modified = {
+        \ 'airline_c': [s:RM[0], s:RM[1], '', '', s:RM[2]]}
+
+  let g:airline#themes#@shortname#palette.replace_modified.airline_warning =
+        \ g:airline#themes#@shortname#palette.normal.airline_warning
+
+  let g:airline#themes#@shortname#palette.tabline = {}
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tab = [
+        \ s:I2[0], s:I2[1], '', '', s:I2[2]]
+
+  let g:airline#themes#@shortname#palette.tabline.airline_tabtype = [
+        \ s:N2[0], s:N2[1], '', '', s:N2[2]]
+endfunction
+
+call airline#themes#@shortname#refresh()
+endauxfile

--- a/templates/xcodedark.colortemplate
+++ b/templates/xcodedark.colortemplate
@@ -37,3 +37,5 @@ Color: green        #84b360 ~
 Color: light_green  #b0e687 ~
 
 Include: _xcodedark
+Include: _airline_dark
+

--- a/templates/xcodedarkhc.colortemplate
+++ b/templates/xcodedarkhc.colortemplate
@@ -37,3 +37,4 @@ Color: green        #8dbf67 ~
 Color: light_green  #b8f08d ~
 
 Include: _xcodedark
+Include: _airline_darkhc

--- a/templates/xcodelight.colortemplate
+++ b/templates/xcodelight.colortemplate
@@ -37,3 +37,4 @@ Color: dark_teal   #23575c ~
 Color: teal        #3e8087 ~
 
 Include: _xcodelight
+Include: _airline_light

--- a/templates/xcodelighthc.colortemplate
+++ b/templates/xcodelighthc.colortemplate
@@ -37,3 +37,4 @@ Color: dark_teal   #174145 ~
 Color: teal        #355d61 ~
 
 Include: _xcodelight
+Include: _airline_lighthc

--- a/templates/xcodewwdc.colortemplate
+++ b/templates/xcodewwdc.colortemplate
@@ -189,3 +189,5 @@ markdownCode      cyan          base2
     Delimiter base7 none
     Operator  base7 none
 #endif
+
+Include: _airline_wwdc


### PR DESCRIPTION
Adds Airline support based on the `solarized` theme from [vim-airline-themes](https://github.com/vim-airline/vim-airline-themes).
Fixes #15.