### PR TITLE
Ignore vim gerated docs tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This prevents a dirty repo status after running `:helptags ALL`.